### PR TITLE
refactor: app details page

### DIFF
--- a/frontend/src/components/app/AppAuthor.vue
+++ b/frontend/src/components/app/AppAuthor.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="media box">
+  <article class="media box author-box">
     <div class="media-content">
       <div class="content">
         <p><strong>{{ fullName }}</strong></p>
@@ -28,3 +28,15 @@ const fullName = computed(() => {
   return [author.firstName, author.lastName].join(' ');
 });
 </script>
+
+<style scoped>
+.author-box {
+  height: 7.5rem;
+  width: 20rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin: 0.5rem;
+}
+</style>

--- a/frontend/src/components/app/AppCard.vue
+++ b/frontend/src/components/app/AppCard.vue
@@ -17,10 +17,6 @@
         </div>
       </div>
 
-      <div class="content">
-        {{ app.description }}
-      </div>
-
       <footer class="card-footer">
         <b-button class="card-footer-item" type="is-ghost" @click.prevent="handleDownload">
           {{ t('download') }}

--- a/frontend/src/pages/AppDetailsPage.vue
+++ b/frontend/src/pages/AppDetailsPage.vue
@@ -2,68 +2,54 @@
   <div class="content-wrapper">
     <b-loading v-if="isLoading" :is-full-page="false" :active="isLoading" />
 
-    <div v-if="task" class="panel pb-5">
+    <div v-if="task" class="panel">
       <p class="panel-heading">
         <b-button class="is-link" icon-pack="fa" icon-left="angle-left" @click="router.back()">
           {{ t('go-back') }}
         </b-button>
       </p>
 
-      <div class="panel-block">
-        <section class="media">
-          <figure class="media-left fixed-image">
-            <app-image :namespace="task.namespace" :version="task.version" />
-          </figure>
-          <div class="media-content m-1 pt-2">
-            <div class="content">
-              <p>
-                <strong class="is-size-2">{{ task.name }}</strong>
-                <br>
-                <span>
-                  <app-author
-                    v-for="(author, index) in task.authors"
-                    :key="index"
-                    :author="author"
-                    class="mb-2 block"
-                  />
-                </span>
-              </p>
+      <div class="card p-4">
+        <section class="columns">
+          <div class="column is-one-quarter">
+            <figure class="image fixed-image">
+              <app-image :namespace="task.namespace" :version="task.version" />
+            </figure>
+          </div>
+
+          <div class="column">
+            <div class="p-2">
+              <h2 class="title is-4">{{ task.name }}</h2>
             </div>
-
-            <div class="media-content">
-              <div class="card">
-                <div class="card-header">
-                  <p class="card-header-title">
-                    {{ t("description") }}
-                  </p>
-                </div>
-
-                <div class="card-content">
-                  <div class="content">
-                    {{ task.description || t('no-description') }}
-                  </div>
-                </div>
-              </div>
+            <div class="px-2 is-flex is-flex-wrap-wrap">
+              <app-author v-for="(author, index) in task.authors" :key="index" :author="author" />
             </div>
           </div>
         </section>
+
+        <section class="columns has-text-centered">
+          <div class="column is-half">
+            <div>
+              <p class="heading">Date</p>
+              <p class="title">{{ task.date || t('unknown') }}</p>
+            </div>
+          </div>
+
+          <div class="column is-half">
+            <div>
+              <p class="heading">Version</p>
+              <p class="title">{{ task.version }}</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="card p-4">
+          <h3 class="title is-5">{{ t("description") }}</h3>
+          <p>
+            {{ task.description || t('no-description') }}
+          </p>
+        </section>
       </div>
-
-      <section class="level mt-5">
-        <div class="level-item has-text-centered">
-          <div>
-            <p class="heading">Date</p>
-            <p class="title">{{ task.date || t('unknown') }}</p>
-          </div>
-        </div>
-
-        <div class="level-item has-text-centered">
-          <div>
-            <p class="heading">Version</p>
-            <p class="title">{{ task.version }}</p>
-          </div>
-        </div>
-      </section>
     </div>
   </div>
 </template>

--- a/frontend/tests/unit/components/app/AppCard.test.ts
+++ b/frontend/tests/unit/components/app/AppCard.test.ts
@@ -48,7 +48,6 @@ describe('AppCard.vue', () => {
     expect(wrapper.text()).toContain(mockTask.name);
     expect(wrapper.text()).toContain(mockTask.date);
     expect(wrapper.text()).toContain(mockTask.version);
-    expect(wrapper.text()).toContain(mockTask.description);
   });
 
   it('should call downloadTask when clicking download', async () => {


### PR DESCRIPTION
# Summary of changes

- Remove the description from the AppCard, so that it does not grow indefinitely in width
- Redesign the App details page for the description to take the whole width

This is what the AppDetailsPage looks like with the refactoring:

<img width="1920" height="1080" alt="Screenshot from 2025-08-22 13-58-07" src="https://github.com/user-attachments/assets/11aa8f80-6056-414a-b76c-a4a2def3e85f" />

---

closes #51 